### PR TITLE
Fix broken peripherals init after boot

### DIFF
--- a/Sources/App/App.swift
+++ b/Sources/App/App.swift
@@ -3,6 +3,10 @@ import RP2040
 @main
 struct App {
     static func main() {
+        // The program must call runtimeInit before using any peripherals.
+        // This should usually be the first thing you call in main().
+        runtimeInit()
+
         let onboardLED = 25
         gpioInit(pin: onboardLED)
         gpioSetDirection(pin: onboardLED, out: true)
@@ -17,11 +21,21 @@ struct App {
     }
 }
 
+/// crt0.s calls this function when `main()` returns.
+///
+/// Most `main()` functions start an infinite loop and never return, in which
+/// case `exit()` isn't needed. But it exists just in case `main()` does return.
+///
+/// The usual implementation is to start an infinite loop, as there is no OS to
+/// return to.
+///
+/// - TODO: Move this into the RP2040 module if possible.
 @_cdecl("exit")
 func exit(_ status: CInt) {
     _exit(status)
 }
 
+/// - TODO: Move this into the RP2040 module if possible.
 @_cdecl("_exit")
 func _exit(_ status: CInt) {
     while true {

--- a/Sources/RP2040/Runtime.swift
+++ b/Sources/RP2040/Runtime.swift
@@ -1,10 +1,20 @@
-/// crt0.S calls this immediately before main.
-@_cdecl("runtime_init")
-func runtimeInit() {
+/// Performs the default initialization after boot. Brings the RP2040
+/// peripherals out of reset and initializes the clocks, incl. ramping up
+/// the CPU clock speed to full.
+///
+/// The program must call this before using any peripherals. This should
+/// usually be the first function you call in `main()`.
+///
+/// - Note: The Raspberry Pi Pico C SDK defines a function called `runtime_init`
+///   and calls it automatically just before calling `main()`. We decided to
+///   make this call an explicit step for transparency into the boot process.
+public func runtimeInit() { 
     // Reset all peripherals to put system into a known state,
     // - except for QSPI pads and the XIP IO bank, as this is fatal if running from flash
     // - and the PLLs, as this is fatal if clock muxing has not been reset on this boot
     // - and USB, syscfg, as this disturbs USB-to-SWD on core 1
+    //
+    // Disables all peripherals except the ones listed in the bitmask.
     resetBlock(bits: ~(
             RESETS_RESET_IO_QSPI_BITS |
             RESETS_RESET_PADS_QSPI_BITS |
@@ -16,6 +26,10 @@ func runtimeInit() {
 
     // Remove reset from peripherals which are clocked only by clk_sys and
     // clk_ref. Other peripherals stay in reset until we've configured clocks.
+    //
+    // Enables all peripherals except the ones listed in the bitmask.
+    // I.e. the peripherals listed here are the ones that
+    // "stay in reset until we've configured clocks".
     unresetBlockAndWait(bits: RESETS_RESET_BITS & ~(
             RESETS_RESET_ADC_BITS |
             RESETS_RESET_RTC_BITS |
@@ -25,4 +39,9 @@ func runtimeInit() {
             RESETS_RESET_UART1_BITS |
             RESETS_RESET_USBCTRL_BITS
     ))
+
+    // Status at this point:
+    // - ADC, RTC, SPI0, SPI1, UART0, UART1 are in reset (= disabled)
+    // - The reset status of USBCTRL is unchanged
+    // - All other peripherals are out of reset (= enabled)
 }

--- a/Sources/RP2040Support/crt0.S
+++ b/Sources/RP2040Support/crt0.S
@@ -229,7 +229,6 @@ _entry_point:
 // Reset handler:
 // - initialises .data
 // - clears .bss
-// - calls runtime_init
 // - calls main
 // - calls exit (which should eventually hang the processor via _exit)
 
@@ -272,8 +271,6 @@ bss_fill_test:
 platform_entry: // symbol for stack traces
     // Use 32-bit jumps, in case these symbols are moved out of branch range
     // (e.g. if main is in SRAM and crt0 in flash)
-    ldr r1, =runtime_init
-    blx r1
     ldr r1, =main
     blx r1
     ldr r1, =exit
@@ -317,16 +314,6 @@ data_cpy_table:
 .word __scratch_y_end__
 
 .word 0 // null terminator
-
-// ----------------------------------------------------------------------------
-// Provide safe defaults for _exit and runtime_init
-// Full implementations usually provided by platform.c
-
-.weak runtime_init
-.type runtime_init,%function
-.thumb_func
-runtime_init:
-    bx lr
 
 // ----------------------------------------------------------------------------
 // If core 1 somehow gets into crt0 due to a spectacular VTOR mishap, we need to


### PR DESCRIPTION
Reverts commit 7978162: Move runtime_init into SDK library.

Fixes #5.

The linker script in the Raspberry Pi Pico C SDK defines a symbol called `runtime_init` and calls that function automatically just before calling `main()`. This is convenient, but it also makes it less obvious what's required to initialize the RP2040 after boot. I decided to make this call an explicit step for transparency into the boot process. Clients must call runtimeInit() from their main() function before they access any peripheral.